### PR TITLE
feat: global error handler middleware

### DIFF
--- a/internal/middleware/error.go
+++ b/internal/middleware/error.go
@@ -21,6 +21,8 @@ func ErrorHandler() gin.HandlerFunc {
 			}
 		}
 
+		// The last attached error determines the response type and status.
+		// Attach errors in order of priority: the most important error last.
 		err := c.Errors.Last()
 		switch err.Type {
 		case gin.ErrorTypePublic:

--- a/internal/middleware/error_test.go
+++ b/internal/middleware/error_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,15 @@ func newRouter() *gin.Engine {
 	r := gin.New()
 	r.Use(ErrorHandler())
 	return r
+}
+
+func decodeBody(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(body), &m); err != nil {
+		t.Fatalf("response body is not valid JSON: %v — body: %s", err, body)
+	}
+	return m
 }
 
 func TestErrorHandler_NoErrors(t *testing.T) {
@@ -51,8 +61,9 @@ func TestErrorHandler_PublicError_WithExplicitStatus(t *testing.T) {
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Errorf("expected 422, got %d", w.Code)
 	}
-	if w.Body.String() == "" {
-		t.Error("expected error body, got empty")
+	body := decodeBody(t, w.Body.String())
+	if body["error"] != "invalid input" {
+		t.Errorf("expected error message 'invalid input', got %v", body["error"])
 	}
 }
 
@@ -67,29 +78,16 @@ func TestErrorHandler_PublicError_DefaultsTo400(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
-		t.Errorf("expected 400 default for public error with 200 status, got %d", w.Code)
+		t.Errorf("expected 400 default for public error, got %d", w.Code)
+	}
+	body := decodeBody(t, w.Body.String())
+	if body["error"] == nil {
+		t.Error("expected non-empty error field in response body")
 	}
 }
 
-func TestErrorHandler_InternalError_Returns500(t *testing.T) {
-	r := newRouter()
-	r.GET("/", func(c *gin.Context) {
-		_ = c.Error(&gin.Error{Err: errors.New("db exploded"), Type: gin.ErrorTypePrivate})
-	})
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest(http.MethodGet, "/", nil)
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusInternalServerError {
-		t.Errorf("expected 500, got %d", w.Code)
-	}
-	if w.Body.String() != `{"error":"internal server error"}` {
-		t.Errorf("expected generic error body, got %s", w.Body.String())
-	}
-}
-
-func TestErrorHandler_InternalError_DoesNotLeakDetails(t *testing.T) {
+// TestErrorHandler_InternalError verifies 500 status, generic message, and no detail leakage.
+func TestErrorHandler_InternalError(t *testing.T) {
 	r := newRouter()
 	r.GET("/", func(c *gin.Context) {
 		_ = c.Error(&gin.Error{Err: errors.New("secret db password is hunter2"), Type: gin.ErrorTypePrivate})
@@ -99,7 +97,61 @@ func TestErrorHandler_InternalError_DoesNotLeakDetails(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/", nil)
 	r.ServeHTTP(w, req)
 
-	if w.Body.String() != `{"error":"internal server error"}` {
-		t.Errorf("internal error detail leaked: %s", w.Body.String())
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+	body := decodeBody(t, w.Body.String())
+	if body["error"] != "internal server error" {
+		t.Errorf("expected generic message, got %v — internal detail may have leaked", body["error"])
+	}
+}
+
+// TestErrorHandler_MultiError_LastErrorWins documents that the last attached error drives the response.
+// Private first, public last → public wins (responds with public message).
+// Public first, private last → private wins (responds with 500).
+func TestErrorHandler_MultiError_LastErrorWins(t *testing.T) {
+	cases := []struct {
+		name           string
+		attachErrors   func(c *gin.Context)
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name: "private then public — last is public",
+			attachErrors: func(c *gin.Context) {
+				_ = c.Error(&gin.Error{Err: errors.New("db error"), Type: gin.ErrorTypePrivate})
+				_ = c.Error(&gin.Error{Err: errors.New("user error"), Type: gin.ErrorTypePublic})
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "user error",
+		},
+		{
+			name: "public then private — last is private",
+			attachErrors: func(c *gin.Context) {
+				_ = c.Error(&gin.Error{Err: errors.New("user error"), Type: gin.ErrorTypePublic})
+				_ = c.Error(&gin.Error{Err: errors.New("db error"), Type: gin.ErrorTypePrivate})
+			},
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "internal server error",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRouter()
+			r.GET("/", func(c *gin.Context) { tc.attachErrors(c) })
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/", nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tc.expectedStatus {
+				t.Errorf("expected %d, got %d", tc.expectedStatus, w.Code)
+			}
+			body := decodeBody(t, w.Body.String())
+			if body["error"] != tc.expectedBody {
+				t.Errorf("expected %q, got %v", tc.expectedBody, body["error"])
+			}
+		})
 	}
 }

--- a/internal/middleware/error_test.go
+++ b/internal/middleware/error_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func newRouter() *gin.Engine {
+	r := gin.New()
+	r.Use(ErrorHandler())
+	return r
+}
+
+func TestErrorHandler_NoErrors(t *testing.T) {
+	r := newRouter()
+	r.GET("/", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if w.Body.String() != "" {
+		t.Errorf("expected empty body, got %s", w.Body.String())
+	}
+}
+
+func TestErrorHandler_PublicError_WithExplicitStatus(t *testing.T) {
+	r := newRouter()
+	r.GET("/", func(c *gin.Context) {
+		c.Status(http.StatusUnprocessableEntity)
+		_ = c.Error(&gin.Error{Err: errors.New("invalid input"), Type: gin.ErrorTypePublic})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422, got %d", w.Code)
+	}
+	if w.Body.String() == "" {
+		t.Error("expected error body, got empty")
+	}
+}
+
+func TestErrorHandler_PublicError_DefaultsTo400(t *testing.T) {
+	r := newRouter()
+	r.GET("/", func(c *gin.Context) {
+		_ = c.Error(&gin.Error{Err: errors.New("bad request"), Type: gin.ErrorTypePublic})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 default for public error with 200 status, got %d", w.Code)
+	}
+}
+
+func TestErrorHandler_InternalError_Returns500(t *testing.T) {
+	r := newRouter()
+	r.GET("/", func(c *gin.Context) {
+		_ = c.Error(&gin.Error{Err: errors.New("db exploded"), Type: gin.ErrorTypePrivate})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+	if w.Body.String() != `{"error":"internal server error"}` {
+		t.Errorf("expected generic error body, got %s", w.Body.String())
+	}
+}
+
+func TestErrorHandler_InternalError_DoesNotLeakDetails(t *testing.T) {
+	r := newRouter()
+	r.GET("/", func(c *gin.Context) {
+		_ = c.Error(&gin.Error{Err: errors.New("secret db password is hunter2"), Type: gin.ErrorTypePrivate})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Body.String() != `{"error":"internal server error"}` {
+		t.Errorf("internal error detail leaked: %s", w.Body.String())
+	}
+}

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -20,6 +20,7 @@ func Logger() gin.HandlerFunc {
 		}
 
 		if len(c.Errors) > 0 {
+			// append extends the base fields slice with the errors key-value pair
 			slog.Error("request", append(fields, "errors", c.Errors.String())...)
 		} else {
 			slog.Info("request", fields...)

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestLogger_SuccessRequest(t *testing.T) {
+	r := gin.New()
+	r.Use(Logger())
+	r.GET("/", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestLogger_ErrorRequest(t *testing.T) {
+	r := gin.New()
+	r.Use(Logger())
+	r.GET("/", func(c *gin.Context) {
+		_ = c.Error(&gin.Error{Err: errors.New("something failed"), Type: gin.ErrorTypePrivate})
+		c.Status(http.StatusInternalServerError)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
* ErrorHandler middleware already implemented in scaffold — this ticket adds full test coverage
* Tests cover: no errors passthrough, public error with explicit status, public error defaulting to 400, internal error returning 500, internal error details not leaked in response body
* Logger middleware tests added for success and error request paths

## Test plan
- [ ] Handler errors surface as structured JSON without each handler writing its own error response
- [ ] Internal error details are never exposed in the response body
- [ ] `go test ./internal/middleware/... -cover` reports 100%