### PR TITLE
feat: add FK constraints to migration runner

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -47,5 +47,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	fkConstraints := []string{
+		`DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_teams_user') THEN ALTER TABLE teams ADD CONSTRAINT fk_teams_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT; END IF; END $$`,
+		`DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_team_agents_team') THEN ALTER TABLE team_agents ADD CONSTRAINT fk_team_agents_team FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE RESTRICT; END IF; END $$`,
+		`DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_runs_team') THEN ALTER TABLE runs ADD CONSTRAINT fk_runs_team FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE RESTRICT; END IF; END $$`,
+		`DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_run_events_run') THEN ALTER TABLE run_events ADD CONSTRAINT fk_run_events_run FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE RESTRICT; END IF; END $$`,
+		`DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_deliverables_run') THEN ALTER TABLE deliverables ADD CONSTRAINT fk_deliverables_run FOREIGN KEY (run_id) REFERENCES runs(id) ON DELETE RESTRICT; END IF; END $$`,
+	}
+
+	for _, stmt := range fkConstraints {
+		if err := db.Exec(stmt).Error; err != nil {
+			slog.Error("failed to apply FK constraint", "error", err, "stmt", stmt)
+			os.Exit(1)
+		}
+	}
+
 	slog.Info("migrations complete")
 }


### PR DESCRIPTION
## Summary
* After AutoMigrate, execute idempotent raw SQL to add 5 FK constraints that GORM's migrator was skipping
* Uses `DO $$ BEGIN IF NOT EXISTS ... END $$` pattern to avoid duplicate constraint errors on re-runs

## Test plan
- [x] Run `go run cmd/migrate/main.go` — completes without error
- [x] Check Supabase Database → Foreign Keys — all 5 constraints visible
- [x] Re-run migrate — no errors (idempotent)

Closes #9