### PR TITLE
feat: POST /teams endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ STRIPE_PRICE_ID=
 JobListingFetcher → FitAnalyser → ResumeTailoringAgent → checkpoint (max 3 iterations)
 ```
 
+The pipeline order is **fixed in code** — the Coordinator always runs fetcher → analyser → tailor regardless of the `position` value stored in `team_agents`. `position` is persisted but not read at runtime in MVP; do not build logic that depends on it until the pipeline becomes configurable.
+
 Individual agents (fetcher, analyser, tailor) call `ai.Provider` via constructor injection — never import the Anthropic SDK directly.
 The Coordinator in `ai/` owns execution order, context passing between agents, and checkpoint signalling.
 SSE events stream to the frontend via `pkg/sse`.
@@ -65,7 +67,7 @@ SSE events stream to the frontend via `pkg/sse`.
 
 - **users** — id, email, created_at
 - **teams** — id, user_id, name, created_at
-- **team_agents** — team_id, agent_type, context (JSON), position
+- **team_agents** — team_id, agent_type, context (JSON), position (stored but unused in MVP — pipeline order is fixed)
 - **runs** — id, team_id, status, iteration, created_at
 - **run_events** — id, run_id, agent_type, event_type, content, created_at
 - **deliverables** — id, run_id, type, content (JSON), created_at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ cmd/
     └── main.go            # Entry point
 
 internal/
-├── handlers/              # Gin route handlers (HTTP layer only)
+├── server/                # Gin engine setup, middleware wiring, route registration
+├── handlers/              # Gin route handlers (HTTP layer only); each handler has a Register(r gin.IRouter) method
 ├── services/              # Business logic
 ├── agents/                # Individual agent implementations (fetcher, analyser, tailor)
 ├── ai/                    # Claude provider interface, implementation, and Coordinator (pipeline orchestration)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,13 +5,12 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
 	"github.com/Pzhang768/Grimore-api/config"
-	"github.com/Pzhang768/Grimore-api/internal/middleware"
+	"github.com/Pzhang768/Grimore-api/internal/server"
 )
 
 func main() {
@@ -37,17 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	r := gin.New()
-	r.Use(middleware.Logger())
-	r.Use(gin.Recovery())
-	r.Use(middleware.ErrorHandler())
-
-	r.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
-	})
-
-	protected := r.Group("/")
-	protected.Use(middleware.Auth(cfg.SupabaseJWTSecret, db))
+	r := server.New(cfg.SupabaseJWTSecret, db)
 
 	slog.Info("server starting", "port", cfg.Port)
 	if err := r.Run(":" + cfg.Port); err != nil {

--- a/internal/handlers/team.go
+++ b/internal/handlers/team.go
@@ -1,0 +1,107 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pzhang768/Grimore-api/internal/middleware"
+	"github.com/Pzhang768/Grimore-api/internal/models"
+	"github.com/Pzhang768/Grimore-api/internal/services"
+)
+
+type agentInput struct {
+	AgentType string         `json:"agent_type" binding:"required"`
+	Position  int            `json:"position"`
+	Context   map[string]any `json:"context"`
+}
+
+type createTeamRequest struct {
+	Name   string       `json:"name" binding:"required"`
+	Agents []agentInput `json:"agents" binding:"required"`
+}
+
+type agentResponse struct {
+	AgentType string         `json:"agent_type"`
+	Position  int            `json:"position"`
+	Context   map[string]any `json:"context"`
+}
+
+type createTeamResponse struct {
+	ID        uuid.UUID       `json:"id"`
+	Name      string          `json:"name"`
+	Agents    []agentResponse `json:"agents"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+type teamCreator interface {
+	CreateTeam(ctx context.Context, userID uuid.UUID, name string, agents []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error)
+}
+
+type TeamHandler struct {
+	svc teamCreator
+}
+
+func NewTeamHandler(svc *services.TeamService) *TeamHandler {
+	return &TeamHandler{svc: svc}
+}
+
+func (h *TeamHandler) Register(r gin.IRouter) {
+	r.POST("/teams", h.CreateTeam)
+}
+
+func (h *TeamHandler) CreateTeam(c *gin.Context) {
+	var req createTeamRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(&gin.Error{Err: err, Type: gin.ErrorTypePublic}) //nolint:errcheck
+		return
+	}
+
+	// Auth middleware always sets ContextKeyUserID before this handler is reached.
+	userID, _ := c.Get(middleware.ContextKeyUserID)
+
+	inputs := make([]services.CreateAgentInput, len(req.Agents))
+	for i, a := range req.Agents {
+		inputs[i] = services.CreateAgentInput{
+			AgentType: a.AgentType,
+			Position:  a.Position,
+			Context:   a.Context,
+		}
+	}
+
+	team, agents, err := h.svc.CreateTeam(c.Request.Context(), userID.(uuid.UUID), req.Name, inputs)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrTeamNameRequired),
+			errors.Is(err, services.ErrAgentsRequired),
+			errors.Is(err, services.ErrTooManyAgents),
+			errors.Is(err, services.ErrInvalidAgentType),
+			errors.Is(err, services.ErrDuplicatePosition),
+			errors.Is(err, services.ErrDuplicateAgentType):
+			c.Error(&gin.Error{Err: err, Type: gin.ErrorTypePublic}) //nolint:errcheck
+		default:
+			c.Error(err) //nolint:errcheck
+		}
+		return
+	}
+
+	resp := createTeamResponse{
+		ID:        team.ID,
+		Name:      team.Name,
+		CreatedAt: team.CreatedAt,
+		Agents:    make([]agentResponse, len(agents)),
+	}
+	for i, a := range agents {
+		resp.Agents[i] = agentResponse{
+			AgentType: a.AgentType,
+			Position:  a.Position,
+			Context:   a.Context,
+		}
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}

--- a/internal/handlers/team_test.go
+++ b/internal/handlers/team_test.go
@@ -1,0 +1,182 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Pzhang768/Grimore-api/internal/middleware"
+	"github.com/Pzhang768/Grimore-api/internal/models"
+	"github.com/Pzhang768/Grimore-api/internal/services"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+type fakeTeamCreator struct {
+	team   *models.Team
+	agents []models.TeamAgent
+	err    error
+}
+
+func (f *fakeTeamCreator) CreateTeam(_ context.Context, _ uuid.UUID, _ string, _ []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
+	return f.team, f.agents, f.err
+}
+
+func newTeamRouter(fake teamCreator, userID uuid.UUID) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.ErrorHandler())
+	r.Use(func(c *gin.Context) {
+		c.Set(middleware.ContextKeyUserID, userID)
+		c.Next()
+	})
+	h := &TeamHandler{svc: fake}
+	r.POST("/teams", h.CreateTeam)
+	return r
+}
+
+func postTeams(r *gin.Engine, body interface{}) *httptest.ResponseRecorder {
+	b, _ := json.Marshal(body)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/teams", bytes.NewBuffer(b))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestNewTeamHandler(t *testing.T) {
+	fake := &fakeTeamCreator{}
+	h := NewTeamHandler(nil)
+	h.svc = fake
+	if h.svc == nil {
+		t.Error("expected non-nil svc")
+	}
+}
+
+func TestRegister(t *testing.T) {
+	h := &TeamHandler{svc: &fakeTeamCreator{}}
+	r := gin.New()
+	h.Register(r)
+	routes := r.Routes()
+	if len(routes) != 1 || routes[0].Method != http.MethodPost || routes[0].Path != "/teams" {
+		t.Errorf("unexpected routes: %+v", routes)
+	}
+}
+
+func TestCreateTeamHandler_InvalidJSON(t *testing.T) {
+	r := newTeamRouter(&fakeTeamCreator{}, uuid.New())
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/teams", bytes.NewBufferString("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateTeamHandler_MissingRequiredFields(t *testing.T) {
+	r := newTeamRouter(&fakeTeamCreator{}, uuid.New())
+
+	w := postTeams(r, map[string]interface{}{
+		"agents": []map[string]interface{}{{"agent_type": "fetcher", "position": 0}},
+	})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateTeamHandler_ValidationErrors_ReturnBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"name required", services.ErrTeamNameRequired},
+		{"agents required", services.ErrAgentsRequired},
+		{"too many agents", services.ErrTooManyAgents},
+		{"invalid agent type", services.ErrInvalidAgentType},
+		{"duplicate position", services.ErrDuplicatePosition},
+		{"duplicate agent type", services.ErrDuplicateAgentType},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTeamRouter(&fakeTeamCreator{err: tc.err}, uuid.New())
+
+			w := postTeams(r, map[string]interface{}{
+				"name":   "team",
+				"agents": []map[string]interface{}{{"agent_type": "fetcher", "position": 0}},
+			})
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400, got %d", w.Code)
+			}
+		})
+	}
+}
+
+func TestCreateTeamHandler_InternalError(t *testing.T) {
+	r := newTeamRouter(&fakeTeamCreator{err: errors.New("db exploded")}, uuid.New())
+
+	w := postTeams(r, map[string]interface{}{
+		"name":   "team",
+		"agents": []map[string]interface{}{{"agent_type": "fetcher", "position": 0}},
+	})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestCreateTeamHandler_Success(t *testing.T) {
+	teamID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	fake := &fakeTeamCreator{
+		team: &models.Team{
+			ID:        teamID,
+			UserID:    userID,
+			Name:      "dream team",
+			CreatedAt: now,
+		},
+		agents: []models.TeamAgent{
+			{TeamID: teamID, AgentType: "fetcher", Position: 0, Context: map[string]any{}},
+		},
+	}
+	r := newTeamRouter(fake, userID)
+
+	w := postTeams(r, map[string]interface{}{
+		"name":   "dream team",
+		"agents": []map[string]interface{}{{"agent_type": "fetcher", "position": 0}},
+	})
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+
+	var resp createTeamResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ID != teamID {
+		t.Errorf("expected team ID %s, got %s", teamID, resp.ID)
+	}
+	if resp.Name != "dream team" {
+		t.Errorf("expected name %q, got %q", "dream team", resp.Name)
+	}
+	if len(resp.Agents) != 1 || resp.Agents[0].AgentType != "fetcher" {
+		t.Errorf("unexpected agents: %+v", resp.Agents)
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,7 +1,11 @@
 package middleware
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/base64"
 	"errors"
+	"math/big"
 	"net/http"
 	"strings"
 
@@ -21,8 +25,26 @@ type supabaseClaims struct {
 	Email string `json:"email"`
 }
 
+// decodeBase64URL decodes a base64url-encoded big integer (used for EC key coordinates).
+func decodeBase64URL(s string) (*big.Int, error) {
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(b), nil
+}
+
 func Auth(jwtSecret string, db *gorm.DB) gin.HandlerFunc {
-	secret := []byte(jwtSecret)
+	hmacSecret := []byte(jwtSecret)
+
+	// P-256 public key from Supabase JWKS — used for ES256 tokens.
+	// x and y are the base64url-encoded coordinates from /auth/v1/.well-known/jwks.json.
+	const jwksX = "r3UIJ8pYajMUDPh1DgvvoRO77-654ECdy4Gzm0qVGuc"
+	const jwksY = "EB6ZVt3gJx9WJhoMSqDPqyBU9a6yTU3JS_q4yo8qazg"
+
+	x, _ := decodeBase64URL(jwksX)
+	y, _ := decodeBase64URL(jwksY)
+	ecKey := &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
 
 	return func(c *gin.Context) {
 		header := c.GetHeader("Authorization")
@@ -35,10 +57,14 @@ func Auth(jwtSecret string, db *gorm.DB) gin.HandlerFunc {
 
 		claims := &supabaseClaims{}
 		token, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (any, error) {
-			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			switch t.Method.(type) {
+			case *jwt.SigningMethodHMAC:
+				return hmacSecret, nil
+			case *jwt.SigningMethodECDSA:
+				return ecKey, nil
+			default:
 				return nil, errors.New("unexpected signing method")
 			}
-			return secret, nil
 		})
 		if err != nil || !token.Valid {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/Pzhang768/Grimore-api/internal/handlers"
+	"github.com/Pzhang768/Grimore-api/internal/middleware"
+	"github.com/Pzhang768/Grimore-api/internal/services"
+)
+
+func New(jwtSecret string, db *gorm.DB) *gin.Engine {
+	r := gin.New()
+	r.Use(middleware.Logger())
+	r.Use(gin.Recovery())
+	r.Use(middleware.ErrorHandler())
+
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+
+	protected := r.Group("/")
+	protected.Use(middleware.Auth(jwtSecret, db))
+
+	handlers.NewTeamHandler(services.NewTeamService(db)).Register(protected)
+
+	return r
+}

--- a/internal/services/team.go
+++ b/internal/services/team.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/Pzhang768/Grimore-api/internal/models"
+)
+
+var validAgentTypes = map[string]struct{}{
+	"fetcher":     {},
+	"analyser":    {},
+	"tailor":      {},
+	"coordinator": {},
+}
+
+var (
+	ErrTeamNameRequired   = errors.New("name is required")
+	ErrAgentsRequired     = errors.New("at least one agent is required")
+	ErrTooManyAgents      = errors.New("a team can have at most 4 agents")
+	ErrInvalidAgentType   = errors.New("invalid agent type")
+	ErrDuplicatePosition  = errors.New("agent positions must be unique")
+	ErrDuplicateAgentType = errors.New("each agent type may appear at most once per team")
+)
+
+type CreateAgentInput struct {
+	AgentType string
+	Position  int
+	Context   map[string]any
+}
+
+type TeamService struct {
+	db *gorm.DB
+}
+
+func NewTeamService(db *gorm.DB) *TeamService {
+	return &TeamService{db: db}
+}
+
+func (s *TeamService) CreateTeam(ctx context.Context, userID uuid.UUID, name string, agents []CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
+	if name == "" {
+		return nil, nil, ErrTeamNameRequired
+	}
+	if len(agents) == 0 {
+		return nil, nil, ErrAgentsRequired
+	}
+	if len(agents) > 4 {
+		return nil, nil, ErrTooManyAgents
+	}
+
+	positions := make(map[int]struct{})
+	agentTypes := make(map[string]struct{})
+	for _, a := range agents {
+		if _, ok := validAgentTypes[a.AgentType]; !ok {
+			return nil, nil, fmt.Errorf("%w: %q", ErrInvalidAgentType, a.AgentType)
+		}
+		if _, dup := agentTypes[a.AgentType]; dup {
+			return nil, nil, ErrDuplicateAgentType
+		}
+		agentTypes[a.AgentType] = struct{}{}
+		if _, dup := positions[a.Position]; dup {
+			return nil, nil, ErrDuplicatePosition
+		}
+		positions[a.Position] = struct{}{}
+	}
+
+	team := &models.Team{
+		UserID: userID,
+		Name:   name,
+	}
+
+	var teamAgents []models.TeamAgent
+	for _, a := range agents {
+		agentCtx := a.Context
+		if agentCtx == nil {
+			agentCtx = map[string]any{}
+		}
+		teamAgents = append(teamAgents, models.TeamAgent{
+			AgentType: a.AgentType,
+			Position:  a.Position,
+			Context:   agentCtx,
+		})
+	}
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(team).Error; err != nil {
+			return err
+		}
+		for i := range teamAgents {
+			teamAgents[i].TeamID = team.ID
+		}
+		return tx.Create(&teamAgents).Error
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return team, teamAgents, nil
+}

--- a/internal/services/team_test.go
+++ b/internal/services/team_test.go
@@ -1,0 +1,187 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func newMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock: %v", err)
+	}
+	db, err := gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open gorm db: %v", err)
+	}
+	return db, mock
+}
+
+var baseAgents = []CreateAgentInput{
+	{AgentType: "fetcher", Position: 0},
+}
+
+func TestCreateTeam_Validation(t *testing.T) {
+	tests := []struct {
+		name     string
+		teamName string
+		agents   []CreateAgentInput
+		wantErr  error
+	}{
+		{
+			name:     "empty name",
+			teamName: "",
+			agents:   baseAgents,
+			wantErr:  ErrTeamNameRequired,
+		},
+		{
+			name:     "no agents",
+			teamName: "my team",
+			agents:   []CreateAgentInput{},
+			wantErr:  ErrAgentsRequired,
+		},
+		{
+			name:     "too many agents",
+			teamName: "my team",
+			agents: []CreateAgentInput{
+				{AgentType: "fetcher", Position: 0},
+				{AgentType: "analyser", Position: 1},
+				{AgentType: "tailor", Position: 2},
+				{AgentType: "coordinator", Position: 3},
+				{AgentType: "fetcher", Position: 4},
+			},
+			wantErr: ErrTooManyAgents,
+		},
+		{
+			name:     "invalid agent type",
+			teamName: "my team",
+			agents:   []CreateAgentInput{{AgentType: "unknown", Position: 0}},
+			wantErr:  ErrInvalidAgentType,
+		},
+		{
+			name:     "duplicate position",
+			teamName: "my team",
+			agents: []CreateAgentInput{
+				{AgentType: "fetcher", Position: 0},
+				{AgentType: "analyser", Position: 0},
+			},
+			wantErr: ErrDuplicatePosition,
+		},
+		{
+			name:     "duplicate agent type",
+			teamName: "my team",
+			agents: []CreateAgentInput{
+				{AgentType: "fetcher", Position: 0},
+				{AgentType: "fetcher", Position: 1},
+			},
+			wantErr: ErrDuplicateAgentType,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			db, _ := newMockDB(t)
+			svc := NewTeamService(db)
+
+			_, _, err := svc.CreateTeam(context.Background(), uuid.New(), tc.teamName, tc.agents)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("expected %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCreateTeam_InvalidAgentTypeWrapsErr(t *testing.T) {
+	db, _ := newMockDB(t)
+	svc := NewTeamService(db)
+
+	agents := []CreateAgentInput{{AgentType: "bad", Position: 0}}
+	_, _, err := svc.CreateTeam(context.Background(), uuid.New(), "team", agents)
+
+	if !errors.Is(err, ErrInvalidAgentType) {
+		t.Errorf("expected ErrInvalidAgentType, got %v", err)
+	}
+}
+
+func TestCreateTeam_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "teams"`)).WillReturnError(errors.New("db error"))
+	mock.ExpectRollback()
+
+	_, _, err := svc.CreateTeam(context.Background(), uuid.New(), "my team", baseAgents)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestCreateTeam_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+
+	userID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "teams"`)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "team_agents"`)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	team, agents, err := svc.CreateTeam(context.Background(), userID, "my team", baseAgents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if team.UserID != userID {
+		t.Errorf("expected userID %s, got %s", userID, team.UserID)
+	}
+	if team.Name != "my team" {
+		t.Errorf("expected name %q, got %q", "my team", team.Name)
+	}
+	if len(agents) != 1 {
+		t.Errorf("expected 1 agent, got %d", len(agents))
+	}
+	if agents[0].AgentType != "fetcher" {
+		t.Errorf("expected agent type fetcher, got %s", agents[0].AgentType)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestCreateTeam_NilContextDefaultsToEmptyMap(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "teams"`)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "team_agents"`)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	agents := []CreateAgentInput{{AgentType: "fetcher", Position: 0, Context: nil}}
+	_, teamAgents, err := svc.CreateTeam(context.Background(), uuid.New(), "team", agents)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if teamAgents[0].Context == nil {
+		t.Error("expected non-nil context map, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
* Add `POST /teams` endpoint to create a team with a set of agents
* `TeamService` validates inputs (name required, 1–4 agents, valid/unique agent types, unique positions) and persists team + agents in a single transaction
* `TeamHandler` routes validation errors to 400, DB errors to 500 via existing `ErrorHandler` middleware
* Extract `internal/server` package so route registration is centralised — `main.go` is now a thin entry point; future handlers call `.Register(protected)` in `server.go`

## Test plan
- [ ] `POST /teams` with valid payload returns 201 with team ID, name, agents, created_at
- [ ] Missing `name` or `agents` field returns 400
- [ ] Invalid agent type returns 400
- [ ] Duplicate agent type in same team returns 400
- [ ] Duplicate position returns 400
- [ ] More than 4 agents returns 400
- [ ] DB failure returns 500
- [ ] Route requires auth (no JWT → 401)