### PR TITLE
feat: GET /teams endpoint

### DIFF
--- a/internal/handlers/team.go
+++ b/internal/handlers/team.go
@@ -38,12 +38,19 @@ type createTeamResponse struct {
 	CreatedAt time.Time       `json:"created_at"`
 }
 
-type teamCreator interface {
+type listTeamItem struct {
+	ID        uuid.UUID `json:"id"`
+	Name      string    `json:"name"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type teamService interface {
 	CreateTeam(ctx context.Context, userID uuid.UUID, name string, agents []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error)
+	ListTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error)
 }
 
 type TeamHandler struct {
-	svc teamCreator
+	svc teamService
 }
 
 func NewTeamHandler(svc *services.TeamService) *TeamHandler {
@@ -51,7 +58,30 @@ func NewTeamHandler(svc *services.TeamService) *TeamHandler {
 }
 
 func (h *TeamHandler) Register(r gin.IRouter) {
+	r.GET("/teams", h.ListTeams)
 	r.POST("/teams", h.CreateTeam)
+}
+
+func (h *TeamHandler) ListTeams(c *gin.Context) {
+	// Auth middleware always sets ContextKeyUserID before this handler is reached.
+	userID, _ := c.Get(middleware.ContextKeyUserID)
+
+	teams, err := h.svc.ListTeams(c.Request.Context(), userID.(uuid.UUID))
+	if err != nil {
+		c.Error(err) //nolint:errcheck
+		return
+	}
+
+	resp := make([]listTeamItem, len(teams))
+	for i, t := range teams {
+		resp[i] = listTeamItem{
+			ID:        t.ID,
+			Name:      t.Name,
+			CreatedAt: t.CreatedAt,
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 func (h *TeamHandler) CreateTeam(c *gin.Context) {

--- a/internal/handlers/team_test.go
+++ b/internal/handlers/team_test.go
@@ -22,17 +22,23 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
-type fakeTeamCreator struct {
-	team   *models.Team
-	agents []models.TeamAgent
-	err    error
+type fakeTeamService struct {
+	team      *models.Team
+	agents    []models.TeamAgent
+	teams     []models.Team
+	createErr error
+	listErr   error
 }
 
-func (f *fakeTeamCreator) CreateTeam(_ context.Context, _ uuid.UUID, _ string, _ []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
-	return f.team, f.agents, f.err
+func (f *fakeTeamService) CreateTeam(_ context.Context, _ uuid.UUID, _ string, _ []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
+	return f.team, f.agents, f.createErr
 }
 
-func newTeamRouter(fake teamCreator, userID uuid.UUID) *gin.Engine {
+func (f *fakeTeamService) ListTeams(_ context.Context, _ uuid.UUID) ([]models.Team, error) {
+	return f.teams, f.listErr
+}
+
+func newTeamRouter(fake teamService, userID uuid.UUID) *gin.Engine {
 	r := gin.New()
 	r.Use(middleware.ErrorHandler())
 	r.Use(func(c *gin.Context) {
@@ -40,7 +46,7 @@ func newTeamRouter(fake teamCreator, userID uuid.UUID) *gin.Engine {
 		c.Next()
 	})
 	h := &TeamHandler{svc: fake}
-	r.POST("/teams", h.CreateTeam)
+	h.Register(r)
 	return r
 }
 
@@ -53,8 +59,15 @@ func postTeams(r *gin.Engine, body interface{}) *httptest.ResponseRecorder {
 	return w
 }
 
+func getTeams(r *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/teams", nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
 func TestNewTeamHandler(t *testing.T) {
-	fake := &fakeTeamCreator{}
+	fake := &fakeTeamService{}
 	h := NewTeamHandler(nil)
 	h.svc = fake
 	if h.svc == nil {
@@ -63,17 +76,79 @@ func TestNewTeamHandler(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	h := &TeamHandler{svc: &fakeTeamCreator{}}
+	h := &TeamHandler{svc: &fakeTeamService{}}
 	r := gin.New()
 	h.Register(r)
 	routes := r.Routes()
-	if len(routes) != 1 || routes[0].Method != http.MethodPost || routes[0].Path != "/teams" {
-		t.Errorf("unexpected routes: %+v", routes)
+	if len(routes) != 2 {
+		t.Fatalf("expected 2 routes, got %d", len(routes))
+	}
+	methods := map[string]bool{}
+	for _, route := range routes {
+		methods[route.Method] = true
+	}
+	if !methods[http.MethodGet] || !methods[http.MethodPost] {
+		t.Errorf("expected GET and POST routes, got %+v", routes)
 	}
 }
 
+// --- ListTeams ---
+
+func TestListTeamsHandler_Success(t *testing.T) {
+	userID := uuid.New()
+	now := time.Now()
+	fake := &fakeTeamService{
+		teams: []models.Team{
+			{ID: uuid.New(), UserID: userID, Name: "team one", CreatedAt: now},
+			{ID: uuid.New(), UserID: userID, Name: "team two", CreatedAt: now},
+		},
+	}
+	r := newTeamRouter(fake, userID)
+	w := getTeams(r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp []listTeamItem
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp) != 2 {
+		t.Errorf("expected 2 teams, got %d", len(resp))
+	}
+}
+
+func TestListTeamsHandler_Empty(t *testing.T) {
+	fake := &fakeTeamService{teams: []models.Team{}}
+	r := newTeamRouter(fake, uuid.New())
+	w := getTeams(r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp []listTeamItem
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp) != 0 {
+		t.Errorf("expected empty array, got %d items", len(resp))
+	}
+}
+
+func TestListTeamsHandler_DBError(t *testing.T) {
+	fake := &fakeTeamService{listErr: errors.New("db error")}
+	r := newTeamRouter(fake, uuid.New())
+	w := getTeams(r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// --- CreateTeam ---
+
 func TestCreateTeamHandler_InvalidJSON(t *testing.T) {
-	r := newTeamRouter(&fakeTeamCreator{}, uuid.New())
+	r := newTeamRouter(&fakeTeamService{}, uuid.New())
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPost, "/teams", bytes.NewBufferString("not-json"))
@@ -86,7 +161,7 @@ func TestCreateTeamHandler_InvalidJSON(t *testing.T) {
 }
 
 func TestCreateTeamHandler_MissingRequiredFields(t *testing.T) {
-	r := newTeamRouter(&fakeTeamCreator{}, uuid.New())
+	r := newTeamRouter(&fakeTeamService{}, uuid.New())
 
 	w := postTeams(r, map[string]interface{}{
 		"agents": []map[string]interface{}{{"agent_type": "fetcher", "position": 0}},
@@ -112,7 +187,7 @@ func TestCreateTeamHandler_ValidationErrors_ReturnBadRequest(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r := newTeamRouter(&fakeTeamCreator{err: tc.err}, uuid.New())
+			r := newTeamRouter(&fakeTeamService{createErr: tc.err}, uuid.New())
 
 			w := postTeams(r, map[string]interface{}{
 				"name":   "team",
@@ -127,7 +202,7 @@ func TestCreateTeamHandler_ValidationErrors_ReturnBadRequest(t *testing.T) {
 }
 
 func TestCreateTeamHandler_InternalError(t *testing.T) {
-	r := newTeamRouter(&fakeTeamCreator{err: errors.New("db exploded")}, uuid.New())
+	r := newTeamRouter(&fakeTeamService{createErr: errors.New("db exploded")}, uuid.New())
 
 	w := postTeams(r, map[string]interface{}{
 		"name":   "team",
@@ -144,7 +219,7 @@ func TestCreateTeamHandler_Success(t *testing.T) {
 	userID := uuid.New()
 	now := time.Now()
 
-	fake := &fakeTeamCreator{
+	fake := &fakeTeamService{
 		team: &models.Team{
 			ID:        teamID,
 			UserID:    userID,

--- a/internal/services/team.go
+++ b/internal/services/team.go
@@ -41,6 +41,14 @@ func NewTeamService(db *gorm.DB) *TeamService {
 	return &TeamService{db: db}
 }
 
+func (s *TeamService) ListTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error) {
+	var teams []models.Team
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&teams).Error; err != nil {
+		return nil, err
+	}
+	return teams, nil
+}
+
 func (s *TeamService) CreateTeam(ctx context.Context, userID uuid.UUID, name string, agents []CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
 	if name == "" {
 		return nil, nil, ErrTeamNameRequired

--- a/internal/services/team_test.go
+++ b/internal/services/team_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
@@ -23,6 +24,73 @@ func newMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 		t.Fatalf("failed to open gorm db: %v", err)
 	}
 	return db, mock
+}
+
+func TestListTeams_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	userID := uuid.New()
+	teamID := uuid.New()
+	now := time.Now()
+
+	rows := sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"}).
+		AddRow(teamID, userID, "team one", now).
+		AddRow(uuid.New(), userID, "team two", now)
+
+	mock.ExpectQuery(`SELECT \* FROM "teams" WHERE user_id`).
+		WithArgs(userID).
+		WillReturnRows(rows)
+
+	teams, err := svc.ListTeams(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(teams) != 2 {
+		t.Errorf("expected 2 teams, got %d", len(teams))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestListTeams_Empty(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	userID := uuid.New()
+
+	rows := sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"})
+	mock.ExpectQuery(`SELECT \* FROM "teams" WHERE user_id`).
+		WithArgs(userID).
+		WillReturnRows(rows)
+
+	teams, err := svc.ListTeams(context.Background(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if teams == nil || len(teams) != 0 {
+		t.Errorf("expected empty slice, got %d", len(teams))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestListTeams_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	userID := uuid.New()
+
+	mock.ExpectQuery(`SELECT \* FROM "teams" WHERE user_id`).
+		WithArgs(userID).
+		WillReturnError(errors.New("db error"))
+
+	_, err := svc.ListTeams(context.Background(), userID)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
 }
 
 var baseAgents = []CreateAgentInput{


### PR DESCRIPTION
## Summary
* Add `GET /teams` — returns all teams for the authenticated user, ordered by `created_at DESC`
* Empty array (not 404) when user has no teams
* Expand handler interface from `teamCreator` to `teamService` to cover both `CreateTeam` and `ListTeams`

## Test plan
- [x] `GET /teams` returns 200 with array of teams for authenticated user
- [x] Returns empty array when no teams exist
- [x] DB error returns 500
- [x] No JWT returns 401