### PR TITLE
feat: GET /teams/:id endpoint

### DIFF
--- a/internal/handlers/team.go
+++ b/internal/handlers/team.go
@@ -47,6 +47,7 @@ type listTeamItem struct {
 type teamService interface {
 	CreateTeam(ctx context.Context, userID uuid.UUID, name string, agents []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error)
 	ListTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error)
+	GetTeam(ctx context.Context, userID, teamID uuid.UUID) (*models.Team, []models.TeamAgent, error)
 }
 
 type TeamHandler struct {
@@ -60,6 +61,47 @@ func NewTeamHandler(svc *services.TeamService) *TeamHandler {
 func (h *TeamHandler) Register(r gin.IRouter) {
 	r.GET("/teams", h.ListTeams)
 	r.POST("/teams", h.CreateTeam)
+	r.GET("/teams/:id", h.GetTeam)
+}
+
+func (h *TeamHandler) GetTeam(c *gin.Context) {
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.Error(&gin.Error{Err: errors.New("invalid team id"), Type: gin.ErrorTypePublic}) //nolint:errcheck
+		return
+	}
+
+	// Auth middleware always sets ContextKeyUserID before this handler is reached.
+	userID, _ := c.Get(middleware.ContextKeyUserID)
+
+	team, agents, err := h.svc.GetTeam(c.Request.Context(), userID.(uuid.UUID), teamID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrTeamNotFound):
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		case errors.Is(err, services.ErrTeamForbidden):
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": err.Error()})
+		default:
+			c.Error(err) //nolint:errcheck
+		}
+		return
+	}
+
+	resp := createTeamResponse{
+		ID:        team.ID,
+		Name:      team.Name,
+		CreatedAt: team.CreatedAt,
+		Agents:    make([]agentResponse, len(agents)),
+	}
+	for i, a := range agents {
+		resp.Agents[i] = agentResponse{
+			AgentType: a.AgentType,
+			Position:  a.Position,
+			Context:   a.Context,
+		}
+	}
+
+	c.JSON(http.StatusOK, resp)
 }
 
 func (h *TeamHandler) ListTeams(c *gin.Context) {

--- a/internal/handlers/team_test.go
+++ b/internal/handlers/team_test.go
@@ -28,6 +28,7 @@ type fakeTeamService struct {
 	teams     []models.Team
 	createErr error
 	listErr   error
+	getErr    error
 }
 
 func (f *fakeTeamService) CreateTeam(_ context.Context, _ uuid.UUID, _ string, _ []services.CreateAgentInput) (*models.Team, []models.TeamAgent, error) {
@@ -36,6 +37,10 @@ func (f *fakeTeamService) CreateTeam(_ context.Context, _ uuid.UUID, _ string, _
 
 func (f *fakeTeamService) ListTeams(_ context.Context, _ uuid.UUID) ([]models.Team, error) {
 	return f.teams, f.listErr
+}
+
+func (f *fakeTeamService) GetTeam(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models.Team, []models.TeamAgent, error) {
+	return f.team, f.agents, f.getErr
 }
 
 func newTeamRouter(fake teamService, userID uuid.UUID) *gin.Engine {
@@ -80,15 +85,15 @@ func TestRegister(t *testing.T) {
 	r := gin.New()
 	h.Register(r)
 	routes := r.Routes()
-	if len(routes) != 2 {
-		t.Fatalf("expected 2 routes, got %d", len(routes))
+	if len(routes) != 3 {
+		t.Fatalf("expected 3 routes, got %d", len(routes))
 	}
-	methods := map[string]bool{}
+	paths := map[string]bool{}
 	for _, route := range routes {
-		methods[route.Method] = true
+		paths[route.Method+route.Path] = true
 	}
-	if !methods[http.MethodGet] || !methods[http.MethodPost] {
-		t.Errorf("expected GET and POST routes, got %+v", routes)
+	if !paths["GET/teams"] || !paths["POST/teams"] || !paths["GET/teams/:id"] {
+		t.Errorf("unexpected routes: %+v", routes)
 	}
 }
 
@@ -250,6 +255,81 @@ func TestCreateTeamHandler_Success(t *testing.T) {
 	}
 	if resp.Name != "dream team" {
 		t.Errorf("expected name %q, got %q", "dream team", resp.Name)
+	}
+	if len(resp.Agents) != 1 || resp.Agents[0].AgentType != "fetcher" {
+		t.Errorf("unexpected agents: %+v", resp.Agents)
+	}
+}
+
+// --- GetTeam ---
+
+func getTeamByID(r *gin.Engine, id string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/teams/"+id, nil)
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestGetTeamHandler_InvalidID(t *testing.T) {
+	r := newTeamRouter(&fakeTeamService{}, uuid.New())
+	w := getTeamByID(r, "not-a-uuid")
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGetTeamHandler_NotFound(t *testing.T) {
+	r := newTeamRouter(&fakeTeamService{getErr: services.ErrTeamNotFound}, uuid.New())
+	w := getTeamByID(r, uuid.New().String())
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetTeamHandler_Forbidden(t *testing.T) {
+	r := newTeamRouter(&fakeTeamService{getErr: services.ErrTeamForbidden}, uuid.New())
+	w := getTeamByID(r, uuid.New().String())
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestGetTeamHandler_InternalError(t *testing.T) {
+	r := newTeamRouter(&fakeTeamService{getErr: errors.New("db error")}, uuid.New())
+	w := getTeamByID(r, uuid.New().String())
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestGetTeamHandler_Success(t *testing.T) {
+	teamID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	fake := &fakeTeamService{
+		team: &models.Team{ID: teamID, UserID: userID, Name: "my team", CreatedAt: now},
+		agents: []models.TeamAgent{
+			{TeamID: teamID, AgentType: "fetcher", Position: 0, Context: map[string]any{}},
+		},
+	}
+	r := newTeamRouter(fake, userID)
+	w := getTeamByID(r, teamID.String())
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var resp createTeamResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ID != teamID {
+		t.Errorf("expected team ID %s, got %s", teamID, resp.ID)
 	}
 	if len(resp.Agents) != 1 || resp.Agents[0].AgentType != "fetcher" {
 		t.Errorf("unexpected agents: %+v", resp.Agents)

--- a/internal/services/team.go
+++ b/internal/services/team.go
@@ -25,6 +25,8 @@ var (
 	ErrInvalidAgentType   = errors.New("invalid agent type")
 	ErrDuplicatePosition  = errors.New("agent positions must be unique")
 	ErrDuplicateAgentType = errors.New("each agent type may appear at most once per team")
+	ErrTeamNotFound       = errors.New("team not found")
+	ErrTeamForbidden      = errors.New("team belongs to another user")
 )
 
 type CreateAgentInput struct {
@@ -39,6 +41,24 @@ type TeamService struct {
 
 func NewTeamService(db *gorm.DB) *TeamService {
 	return &TeamService{db: db}
+}
+
+func (s *TeamService) GetTeam(ctx context.Context, userID, teamID uuid.UUID) (*models.Team, []models.TeamAgent, error) {
+	var team models.Team
+	if err := s.db.WithContext(ctx).First(&team, "id = ?", teamID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, ErrTeamNotFound
+		}
+		return nil, nil, err
+	}
+	if team.UserID != userID {
+		return nil, nil, ErrTeamForbidden
+	}
+	var agents []models.TeamAgent
+	if err := s.db.WithContext(ctx).Where("team_id = ?", teamID).Find(&agents).Error; err != nil {
+		return nil, nil, err
+	}
+	return &team, agents, nil
 }
 
 func (s *TeamService) ListTeams(ctx context.Context, userID uuid.UUID) ([]models.Team, error) {

--- a/internal/services/team_test.go
+++ b/internal/services/team_test.go
@@ -93,6 +93,121 @@ func TestListTeams_DBError(t *testing.T) {
 	}
 }
 
+func TestGetTeam_NotFound(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	teamID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "teams"`)).
+		WithArgs(teamID, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"}))
+
+	_, _, err := svc.GetTeam(context.Background(), uuid.New(), teamID)
+	if !errors.Is(err, ErrTeamNotFound) {
+		t.Errorf("expected ErrTeamNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestGetTeam_Forbidden(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	teamID := uuid.New()
+	ownerID := uuid.New()
+	callerID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "teams"`)).
+		WithArgs(teamID, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"}).
+			AddRow(teamID, ownerID, "team", now))
+
+	_, _, err := svc.GetTeam(context.Background(), callerID, teamID)
+	if !errors.Is(err, ErrTeamForbidden) {
+		t.Errorf("expected ErrTeamForbidden, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestGetTeam_DBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	teamID := uuid.New()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "teams"`)).
+		WithArgs(teamID, 1).
+		WillReturnError(errors.New("db error"))
+
+	_, _, err := svc.GetTeam(context.Background(), uuid.New(), teamID)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestGetTeam_Success(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	teamID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "teams"`)).
+		WithArgs(teamID, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"}).
+			AddRow(teamID, userID, "my team", now))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "team_agents"`)).
+		WithArgs(teamID).
+		WillReturnRows(sqlmock.NewRows([]string{"team_id", "agent_type", "position", "context"}).
+			AddRow(teamID, "fetcher", 0, "{}"))
+
+	team, agents, err := svc.GetTeam(context.Background(), userID, teamID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if team.ID != teamID {
+		t.Errorf("expected team ID %s, got %s", teamID, team.ID)
+	}
+	if len(agents) != 1 || agents[0].AgentType != "fetcher" {
+		t.Errorf("unexpected agents: %+v", agents)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+func TestGetTeam_AgentsDBError(t *testing.T) {
+	db, mock := newMockDB(t)
+	svc := NewTeamService(db)
+	teamID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "teams"`)).
+		WithArgs(teamID, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "name", "created_at"}).
+			AddRow(teamID, userID, "my team", now))
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "team_agents"`)).
+		WithArgs(teamID).
+		WillReturnError(errors.New("db error"))
+
+	_, _, err := svc.GetTeam(context.Background(), userID, teamID)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
 var baseAgents = []CreateAgentInput{
 	{AgentType: "fetcher", Position: 0},
 }


### PR DESCRIPTION
## Summary
* Add `GET /teams/:id` — returns team detail with agents for the authenticated user
* 404 if team not found, 403 if team belongs to another user, 400 if ID is not a valid UUID
* Agents are loaded in a second query after the team ownership check

## Test plan
- [x] Valid team ID returns 200 with team + agents
- [x] Unknown team ID returns 404
- [x] Team owned by another user returns 403
- [x] Invalid UUID returns 400
- [x] No JWT returns 401