### PR TITLE
feat: agent registry and GET /agents endpoint

### DIFF
--- a/internal/agents/agent.go
+++ b/internal/agents/agent.go
@@ -1,0 +1,25 @@
+package agents
+
+import "context"
+
+type ContextField struct {
+	Key      string `json:"key"`
+	Label    string `json:"label"`
+	Required bool   `json:"required"`
+}
+
+type AgentInput struct {
+	Context map[string]any
+	Payload string
+}
+
+type AgentOutput struct {
+	Content string
+}
+
+type Agent interface {
+	Type() string
+	Description() string
+	ContextSchema() []ContextField
+	Run(ctx context.Context, input AgentInput) (AgentOutput, error)
+}

--- a/internal/agents/analyser.go
+++ b/internal/agents/analyser.go
@@ -1,0 +1,16 @@
+package agents
+
+import "context"
+
+type Analyser struct{}
+
+func (a *Analyser) Type() string        { return "analyser" }
+func (a *Analyser) Description() string { return "Scores fit between job listings and your resume" }
+func (a *Analyser) ContextSchema() []ContextField {
+	return []ContextField{
+		{Key: "min_fit_score", Label: "Minimum fit score (0–100)", Required: false},
+	}
+}
+func (a *Analyser) Run(_ context.Context, _ AgentInput) (AgentOutput, error) {
+	return AgentOutput{Content: "stub: analyser not yet implemented"}, nil
+}

--- a/internal/agents/coordinator.go
+++ b/internal/agents/coordinator.go
@@ -1,0 +1,16 @@
+package agents
+
+import "context"
+
+type Coordinator struct{}
+
+func (c *Coordinator) Type() string        { return "coordinator" }
+func (c *Coordinator) Description() string { return "Passes context between agents and signals completion" }
+func (c *Coordinator) ContextSchema() []ContextField {
+	return []ContextField{
+		{Key: "max_iterations", Label: "Max iterations (default 3)", Required: false},
+	}
+}
+func (c *Coordinator) Run(_ context.Context, _ AgentInput) (AgentOutput, error) {
+	return AgentOutput{Content: "stub: coordinator not yet implemented"}, nil
+}

--- a/internal/agents/fetcher.go
+++ b/internal/agents/fetcher.go
@@ -1,0 +1,18 @@
+package agents
+
+import "context"
+
+type Fetcher struct{}
+
+func (f *Fetcher) Type() string        { return "fetcher" }
+func (f *Fetcher) Description() string { return "Finds relevant job listings based on role and location" }
+func (f *Fetcher) ContextSchema() []ContextField {
+	return []ContextField{
+		{Key: "role_title", Label: "Role title", Required: true},
+		{Key: "location", Label: "Location", Required: false},
+		{Key: "keywords", Label: "Keywords", Required: false},
+	}
+}
+func (f *Fetcher) Run(_ context.Context, _ AgentInput) (AgentOutput, error) {
+	return AgentOutput{Content: "stub: fetcher not yet implemented"}, nil
+}

--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -1,0 +1,8 @@
+package agents
+
+var Registry = map[string]Agent{
+	"fetcher":     &Fetcher{},
+	"analyser":    &Analyser{},
+	"tailor":      &Tailor{},
+	"coordinator": &Coordinator{},
+}

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -1,0 +1,57 @@
+package agents
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRegistry_ContainsAllAgentTypes(t *testing.T) {
+	expected := []string{"fetcher", "analyser", "tailor", "coordinator"}
+	for _, agentType := range expected {
+		if _, ok := Registry[agentType]; !ok {
+			t.Errorf("registry missing agent type %q", agentType)
+		}
+	}
+}
+
+func TestRegistry_TypeMatchesKey(t *testing.T) {
+	for key, a := range Registry {
+		if a.Type() != key {
+			t.Errorf("agent key %q has Type() %q — they must match", key, a.Type())
+		}
+	}
+}
+
+func TestRegistry_AllAgentsHaveDescription(t *testing.T) {
+	for _, a := range Registry {
+		if a.Description() == "" {
+			t.Errorf("agent %q has empty description", a.Type())
+		}
+	}
+}
+
+func TestRegistry_AllAgentsHaveContextSchema(t *testing.T) {
+	for _, a := range Registry {
+		schema := a.ContextSchema()
+		if schema == nil {
+			t.Errorf("agent %q returned nil context schema", a.Type())
+		}
+		for _, field := range schema {
+			if field.Key == "" || field.Label == "" {
+				t.Errorf("agent %q has context field with empty key or label: %+v", a.Type(), field)
+			}
+		}
+	}
+}
+
+func TestRegistry_AllAgentsRun(t *testing.T) {
+	for _, a := range Registry {
+		out, err := a.Run(context.Background(), AgentInput{})
+		if err != nil {
+			t.Errorf("agent %q Run() returned error: %v", a.Type(), err)
+		}
+		if out.Content == "" {
+			t.Errorf("agent %q Run() returned empty content", a.Type())
+		}
+	}
+}

--- a/internal/agents/tailor.go
+++ b/internal/agents/tailor.go
@@ -1,0 +1,16 @@
+package agents
+
+import "context"
+
+type Tailor struct{}
+
+func (t *Tailor) Type() string        { return "tailor" }
+func (t *Tailor) Description() string { return "Rewrites your resume to match each job listing" }
+func (t *Tailor) ContextSchema() []ContextField {
+	return []ContextField{
+		{Key: "tone", Label: "Tone (e.g. professional, concise)", Required: false},
+	}
+}
+func (t *Tailor) Run(_ context.Context, _ AgentInput) (AgentOutput, error) {
+	return AgentOutput{Content: "stub: tailor not yet implemented"}, nil
+}

--- a/internal/handlers/agent.go
+++ b/internal/handlers/agent.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pzhang768/Grimore-api/internal/agents"
+)
+
+type agentDefinition struct {
+	AgentType     string                `json:"agent_type"`
+	Description   string                `json:"description"`
+	ContextSchema []agents.ContextField `json:"context_schema"`
+}
+
+type AgentHandler struct{}
+
+func NewAgentHandler() *AgentHandler {
+	return &AgentHandler{}
+}
+
+func (h *AgentHandler) Register(r gin.IRouter) {
+	r.GET("/agents", h.ListAgents)
+}
+
+func (h *AgentHandler) ListAgents(c *gin.Context) {
+	resp := make([]agentDefinition, 0, len(agents.Registry))
+	for _, a := range agents.Registry {
+		resp = append(resp, agentDefinition{
+			AgentType:     a.Type(),
+			Description:   a.Description(),
+			ContextSchema: a.ContextSchema(),
+		})
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/handlers/agent_test.go
+++ b/internal/handlers/agent_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Pzhang768/Grimore-api/internal/agents"
+)
+
+func TestNewAgentHandler(t *testing.T) {
+	h := NewAgentHandler()
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}
+
+func TestAgentRegister(t *testing.T) {
+	r := gin.New()
+	NewAgentHandler().Register(r)
+	routes := r.Routes()
+	if len(routes) != 1 || routes[0].Method != http.MethodGet || routes[0].Path != "/agents" {
+		t.Errorf("unexpected routes: %+v", routes)
+	}
+}
+
+func TestListAgents_ReturnsAllAgents(t *testing.T) {
+	r := gin.New()
+	NewAgentHandler().Register(r)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/agents", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var resp []agentDefinition
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(resp) != len(agents.Registry) {
+		t.Errorf("expected %d agents, got %d", len(agents.Registry), len(resp))
+	}
+
+	for _, def := range resp {
+		if def.AgentType == "" {
+			t.Error("agent definition has empty agent_type")
+		}
+		if def.Description == "" {
+			t.Error("agent definition has empty description")
+		}
+		if def.ContextSchema == nil {
+			t.Errorf("agent %q has nil context_schema", def.AgentType)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ func New(jwtSecret string, db *gorm.DB) *gin.Engine {
 	r.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{"status": "ok"})
 	})
+	handlers.NewAgentHandler().Register(r)
 
 	protected := r.Group("/")
 	protected.Use(middleware.Auth(jwtSecret, db))


### PR DESCRIPTION
## Summary
* Define `Agent` interface with `Type()`, `Description()`, `ContextSchema()`, `Run()` in `internal/agents/`
* Implement all four agents (`fetcher`, `analyser`, `tailor`, `coordinator`) with stubs for `Run` — real Claude calls come in a later ticket
* `internal/agents/Registry` map provides a single source of truth for all agent types
* `GET /agents` is public (no auth) — returns agent type, description, and context schema for each agent

## Test plan
- [ ] `GET /agents` returns all 4 agents with non-empty type, description, and context_schema
- [ ] No JWT required
- [ ] Registry keys match each agent's `Type()` return value